### PR TITLE
1 ホスト上で複数 Athrill を起動した場合に、ROS 通信・リモートデバッグ機能を利用できるようにする

### DIFF
--- a/src/device/peripheral/mros-dev/mros-athrill/config/mros_sys_config.h
+++ b/src/device/peripheral/mros-dev/mros-athrill/config/mros_sys_config.h
@@ -5,6 +5,7 @@
 extern "C" {
 #endif
 
+#include "std_types.h"
 #include "mros_usr_config.h"
 #include "mros_os_config.h"
 #include "mros_packet_config.h"
@@ -25,6 +26,8 @@ extern "C" {
 
 extern char *mros_master_ipaddr;
 extern char *mros_node_ipaddr;
+extern uint32 mros_slave_port_no;
+extern uint32 mros_publisher_port_no;
 extern char *mros_uri_slave;
 
 /*

--- a/src/device/peripheral/mros-dev/mros-athrill/device/athrill_mros_device.c
+++ b/src/device/peripheral/mros-dev/mros-athrill/device/athrill_mros_device.c
@@ -157,6 +157,8 @@ static int athrill_mros_device_sub_init(AthrillMrosDevSubReqType *reqs, int req_
 
 char *mros_master_ipaddr = MROS_MASTER_IPADDR;
 char *mros_node_ipaddr = MROS_NODE_IPADDR;
+uint32 mros_slave_port_no = MROS_SLAVE_PORT_NO;
+uint32 mros_publisher_port_no = MROS_PUBLISHER_PORT_NO;
 static char mros_uri_slave_buffer[4096];
 char *mros_uri_slave = &mros_uri_slave_buffer[0];
 
@@ -169,9 +171,13 @@ static void *athrill_mros_device_main(void *arg)
 	memset(mros_uri_slave_buffer, 0, sizeof(mros_uri_slave_buffer));
 	(void)cpuemu_get_devcfg_string("DEBUG_FUNC_MROS_MASTER_IPADDR", &mros_master_ipaddr);
 	(void)cpuemu_get_devcfg_string("DEBUG_FUNC_MROS_NODE_IPADDR", &mros_node_ipaddr);
+	(void)cpuemu_get_devcfg_value("DEBUG_FUNC_MROS_SLAVE_PORT_NO", &mros_slave_port_no);
+	(void)cpuemu_get_devcfg_value("DEBUG_FUNC_MROS_PUBLISHER_PORT_NO", &mros_publisher_port_no);
 	printf("mros_master_ipaddr=%s\n", mros_master_ipaddr);
-	snprintf(mros_uri_slave_buffer, sizeof(mros_uri_slave_buffer), "http://%s:%d", mros_node_ipaddr, MROS_SLAVE_PORT_NO);
+	printf("mros_slave_port_no=%d\n", mros_slave_port_no);
+	snprintf(mros_uri_slave_buffer, sizeof(mros_uri_slave_buffer), "http://%s:%d", mros_node_ipaddr, mros_slave_port_no);
 	printf("mros_uri_slave=%s\n", mros_uri_slave);
+	printf("mros_publisher_port_no=%d\n", mros_publisher_port_no);
 
 	set_main_task();
 	main_task();

--- a/src/device/peripheral/mros-dev/mros-src/os/target/os_asp/mros_test.c
+++ b/src/device/peripheral/mros-dev/mros-src/os/target/os_asp/mros_test.c
@@ -16,7 +16,7 @@ void do_test_server(void)
 		return;
 	}
 	(void)mros_comm_socket_set_blocking(&server.socket, MROS_FALSE, MROS_SLAVE_TIMEOUT);
-	ret =  mros_comm_tcp_server_bind(&server, MROS_SLAVE_PORT_NO);
+	ret =  mros_comm_tcp_server_bind(&server, mros_slave_port_no);
 	if (ret != MROS_E_OK) {
 		syslog(LOG_NOTICE, "mros_comm_tcp_server_bind()=%d", ret);
 		return;

--- a/src/device/peripheral/mros-dev/mros-src/packet/cimpl/mros_packet_encoder_cimpl.h
+++ b/src/device/peripheral/mros-dev/mros-src/packet/cimpl/mros_packet_encoder_cimpl.h
@@ -46,7 +46,7 @@ extern mRosReturnType mros_packet_encoder_init(void);
  */
 /*
  *	arg.type = MROS_PACKET_DATA_REQUEST_TOPIC_RES;
- *	arg.argi[0] = MROS_PUBLISHER_PORT_NO;
+ *	arg.argi[0] = mros_publisher_port_no;
  *	arg.argv[0] ="TCPROS";
  *	arg.argv[1] = MROS_NODE_IPADDR;
  */

--- a/src/device/peripheral/mros-dev/mros-src/protocol/cimpl/mros_protocol_master_cimpl.c
+++ b/src/device/peripheral/mros-dev/mros-src/protocol/cimpl/mros_protocol_master_cimpl.c
@@ -221,11 +221,6 @@ static mRosReturnType mros_protocol_master_register_subscriber(mRosProtocolMaste
 	}
 	while (ptr != MROS_NULL) {
 		mRosCommTcpClientType client;
-		if (ipaddr == mros_protocol_master.self_ipaddr) {
-			ptr = mros_xmlpacket_subres_get_next_uri(ptr, rpc_regc_res.reply_packet, &ipaddr, &port);
-			continue;
-		}
-
 		ret = mros_comm_tcp_client_ip32_init(&client, ipaddr, port);
 		if (ret != MROS_E_OK) {
 			ROS_ERROR("%s %s() %u ret=%d", __FILE__, __FUNCTION__, __LINE__, ret);

--- a/src/device/peripheral/mros-dev/mros-src/protocol/cimpl/mros_protocol_publish_cimpl.c
+++ b/src/device/peripheral/mros-dev/mros-src/protocol/cimpl/mros_protocol_publish_cimpl.c
@@ -31,7 +31,7 @@ mRosReturnType mros_protocol_publish_init(void)
 	mros_protocol_publish.packet.total_size = sizeof(mRosPublishPacketBufferType);
 	mros_protocol_publish.packet.data = &mros_publish_packet_buffer.buffer;
 	mros_protocol_publish.state = MROS_PROTOCOL_PUBLISH_STATE_WAITING;
-	ret =  mros_comm_tcp_server_bind(&mros_protocol_publish.server_comm, MROS_PUBLISHER_PORT_NO);
+	ret =  mros_comm_tcp_server_bind(&mros_protocol_publish.server_comm, mros_publisher_port_no);
 	if (ret != MROS_E_OK) {
 		ROS_ERROR("%s %s() %u ret=%d", __FILE__, __FUNCTION__, __LINE__, ret);
 		return ret;

--- a/src/device/peripheral/mros-dev/mros-src/protocol/cimpl/mros_protocol_server_proc_cimpl.c
+++ b/src/device/peripheral/mros-dev/mros-src/protocol/cimpl/mros_protocol_server_proc_cimpl.c
@@ -255,10 +255,6 @@ static mRosReturnType mros_proc_slave_publisher_update(mRosCommTcpClientType *cl
 	ret = MROS_E_OK;
 	ptr = mros_xmlpacket_pubupreq_get_first_uri(&mros_proc_slave_decoded_requst.request.publisher_update.topic_name.res.tail[1], &tcp_conn.ipaddr, &tcp_conn.port);
 	while (ptr != MROS_NULL) {
-		if (tcp_conn.ipaddr == self_ipaddr) {
-			ptr = mros_xmlpacket_pubupreq_get_next_uri(ptr, packet, &tcp_conn.ipaddr, &tcp_conn.port);
-			continue;
-		}
 		if (mros_proc_connector_get_first(topic_id, MROS_TOPIC_CONNECTOR_PUB, MROS_NODE_TYPE_OUTER, &tcp_conn) != MROS_ID_NONE) {
 			ptr = mros_xmlpacket_pubupreq_get_next_uri(ptr, packet, &tcp_conn.ipaddr, &tcp_conn.port);
 			continue;

--- a/src/device/peripheral/mros-dev/mros-src/protocol/cimpl/mros_protocol_server_proc_cimpl.c
+++ b/src/device/peripheral/mros-dev/mros-src/protocol/cimpl/mros_protocol_server_proc_cimpl.c
@@ -133,7 +133,7 @@ static mRosReturnType mros_proc_slave_request_topic(mRosCommTcpClientType *clien
 		mRosEncodeArgType arg;
 		arg.type = MROS_PACKET_DATA_REQUEST_TOPIC_RES;
 		arg.args_int = 1;
-		arg.argi[0] = MROS_PUBLISHER_PORT_NO;
+		arg.argi[0] = mros_publisher_port_no;
 		arg.args_char = 2;
 		arg.argv[0] ="TCPROS";
 		arg.argv[1] = mros_node_ipaddr;

--- a/src/device/peripheral/mros-dev/mros-src/protocol/cimpl/mros_protocol_slave_cimpl.c
+++ b/src/device/peripheral/mros-dev/mros-src/protocol/cimpl/mros_protocol_slave_cimpl.c
@@ -36,7 +36,7 @@ mRosReturnType mros_protocol_slave_init(void)
 	mros_protocol_slave.packet.total_size = sizeof(mRosSlavePacketBufferType);
 	mros_protocol_slave.packet.data = &mros_slave_packet_buffer.buffer;
 	mros_protocol_slave.state = MROS_PROTOCOL_SLAVE_STATE_WAITING;
-	ret =  mros_comm_tcp_server_bind(&mros_protocol_slave.server_comm, MROS_SLAVE_PORT_NO);
+	ret =  mros_comm_tcp_server_bind(&mros_protocol_slave.server_comm, mros_slave_port_no);
 	if (ret != MROS_E_OK) {
 		ROS_ERROR("%s %s() %u ret=%d", __FILE__, __FUNCTION__, __LINE__, ret);
 		return ret;

--- a/src/lib/cui/udp/cui_ops_udp.c
+++ b/src/lib/cui/udp/cui_ops_udp.c
@@ -14,25 +14,30 @@ static void cui_close_udp(void);
 static int  cui_getline_udp(char *line, int size);
 static void cui_write_udp(char *line, int size);
 
-static UdpFileOpType cui_fileop_udp = {
-	.config = {
-			.server_port = CPUEMU_CONFIG_CUI_EMULATOR_PORTNO,
-			.client_port = CPUEMU_CONFIG_CUI_CLIENT_PORTNO,
-			.is_wait = TRUE,
-	},
-	.op = {
-			.cui_getline = cui_getline_udp,
-			.cui_write = cui_write_udp,
-			.cui_close = cui_close_udp,
-	},
-};
+static UdpFileOpType cui_fileop_udp;
 
-void cui_ops_udp_init(void)
+void cui_ops_udp_init(uint16 server_port, uint16 client_port)
 {
 	Std_ReturnType err;
 
-	printf("REMOTE:server port %u\n", cui_fileop_udp.config.server_port);
-	printf("REMOTE:client port %u\n", cui_fileop_udp.config.client_port);
+	UdpFileOpType cui_fileop_udp_tmp = {
+		.config = {
+				.server_port = server_port,
+				.client_port = client_port,
+				.is_wait = TRUE,
+		},
+		.op = {
+				.cui_getline = cui_getline_udp,
+				.cui_write = cui_write_udp,
+				.cui_close = cui_close_udp,
+		},
+
+	};
+
+	cui_fileop_udp = cui_fileop_udp_tmp;
+
+	printf("REMOTE:athrill listen port %u\n", cui_fileop_udp.config.server_port);
+	printf("REMOTE:client listen port %u\n", cui_fileop_udp.config.client_port);
 
 	err = udp_comm_create(&cui_fileop_udp.config, &cui_fileop_udp.comm);
 	if (err != STD_E_OK) {

--- a/src/lib/cui/udp/cui_ops_udp.h
+++ b/src/lib/cui/udp/cui_ops_udp.h
@@ -1,6 +1,6 @@
 #ifndef _CUI_OPS_UDP_H_
 #define _CUI_OPS_UDP_H_
 
-extern void cui_ops_udp_init(void);
+extern void cui_ops_udp_init(uint16 server_port, uint16 client_port);
 
 #endif /* _CUI_OPS_UDP_H_ */

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -3,6 +3,7 @@
 #include "option/option.h"
 #include "cpu_control/dbg_cpu_control.h"
 #include "cpu_control/dbg_cpu_thread_control.h"
+#include "cpuemu_config.h"
 #include "cpuemu_ops.h"
 #include "cui/cui_ops.h"
 #include "cui/stdio/cui_ops_stdio.h"
@@ -222,7 +223,11 @@ int main(int argc, const char *argv[])
 
 	if (opt->is_interaction == TRUE) {
 		if (opt->is_remote == TRUE) {
-			cui_ops_udp_init();
+			uint32 athrill_listen_port = CPUEMU_CONFIG_CUI_EMULATOR_PORTNO;
+			uint32 client_listen_port = CPUEMU_CONFIG_CUI_CLIENT_PORTNO;
+			(void)cpuemu_get_devcfg_value("DEBUG_FUNC_REMOTE_ATHRILL_LISTEN_PORT_NO", &athrill_listen_port);
+			(void)cpuemu_get_devcfg_value("DEBUG_FUNC_REMOTE_CLIENT_LISTEN_PORT_NO", &client_listen_port);
+			cui_ops_udp_init((uint16)client_listen_port, (uint16)athrill_listen_port);
 		}
 		else {
 			cui_ops_stdio_init();


### PR DESCRIPTION
#44 の対応です。

device_config に以下項目を追加し、デフォルト値から変更可能にしました。

# device_config.txt に追加した項目

- リモートデバッグ機能
    - `DEBUG_FUNC_REMOTE_ATHRILL_LISTEN_PORT_NO`
        - athrill_remote -> athrill のポート番号
    - `DEBUG_FUNC_REMOTE_CLIENT_LISTEN_PORT_NO`
        - athrill -> athrill_remote のポート番号
    - athrill_remote は、コマンドラインオプションでポート番号を指定できるように修正
- ROS 通信機能 
    - `DEBUG_FUNC_MROS_SLAVE_PORT_NO`
        - MROS スレーブポート番号
    - `DEBUG_FUNC_MROS_PUBLISHER_PORT_NO`
        - パブリッシャー待ち受けポート番号
