### PR TITLE
デバイス供給クロックがタイマ分周に合わない場合、実時間同期機能が正しく動かない問題を修正。

### DIFF
--- a/src/main/cpuemu.c
+++ b/src/main/cpuemu.c
@@ -486,7 +486,7 @@ void *cpuemu_thread_run(void* arg)
 		is_halt = do_cpu_run(core_id_num);
 
 		if (enable_skip == TRUE) {
-			if ((is_halt == TRUE) && (cpuemu_dev_clock.can_skip_clock == TRUE)) {
+			if ((is_halt == TRUE) && (cpuemu_dev_clock.can_skip_clock == TRUE) && (cpuemu_dev_clock.min_intr_interval != DEVICE_CLOCK_MAX_INTERVAL)) {
 #ifdef OS_LINUX
 				uint64 skipc_usec = 0;
 				if (enable_dbg.enable_sync_time > 0) {


### PR DESCRIPTION
https://github.com/toppers/athrill-target-rh850f1x/issues/20 の修正対応です。

コメントの修正案の通り、 `cpuemu.c ` の `L489` に `cpuemu_dev_clock.min_intr_interval != DEVICE_CLOCK_MAX_INTERVAL` の条件を追加し、改善されることを確認しました。