### PR TITLE
athrilllの引数が無い場合のmain関数の戻り値を見直しました

### DIFF
--- a/src/main/main.c
+++ b/src/main/main.c
@@ -167,7 +167,7 @@ int main(int argc, const char *argv[])
 		printf(" %-30s : set athrill memory configuration. rom, ram region is configured on your system.\n", "-m<memory config file>");
 		//printf(" %-30s : set communication path with an another emulator.\n", "-p<fifo config file>");
 		printf(" %-30s : set device parameter.\n", "-d<device config file>");
-		return -11;
+		return 0;
 	}
 
 	winsock_init();


### PR DESCRIPTION
athrillの引数が無い場合にはバージョン情報とヘルプが出力されますが、その場合の戻り値が-11になっています。
引数が無いことを利用したスクリプトなど影響がなければ、正常系の処理だと思いますので戻り値を0にしてもらいたいです。