### PR TITLE
Support arm64-linux variant hosts.

### DIFF
--- a/src/inc/std_types.h
+++ b/src/inc/std_types.h
@@ -42,7 +42,7 @@ typedef uint32 CoreIdType;
 #define CAST_UINT32_TO_ADDR(uint32_data) ( (void*)((uint32)(uint32_data)) )
 #elif __x86_64__
 #define CAST_UINT32_TO_ADDR(uint32_data) ( (void*)((uint64)(uint32_data)) )
-#elif __arm64
+#elif defined(__arm64) || defined(__arm64__) || defined(__aarch64__)
 #define CAST_UINT32_TO_ADDR(uint32_data) ( (void*)((uint64)(uint32_data)) )
 #else
 #error "unknown arch."


### PR DESCRIPTION
Some versions of gcc doesn't provide `__arm64` as a pre-defined macro.