### PR TITLE
Windows ホスト(MinGW)でビルドするためにコードをコメントアウトしました

### DIFF
--- a/apl/include/athrill_syscall.h
+++ b/apl/include/athrill_syscall.h
@@ -310,9 +310,11 @@ static inline int athrill_newlib_open_r_flag(int org_flags)
 	ATHRILL_OPEN_R_FLAG_TARGET2INF(flags, org_flags, O_APPEND);
 	ATHRILL_OPEN_R_FLAG_TARGET2INF(flags, org_flags, O_CREAT);
 	ATHRILL_OPEN_R_FLAG_TARGET2INF(flags, org_flags, O_EXCL);
+#if OS_LINUX    /* Windows not support */
 	ATHRILL_OPEN_R_FLAG_TARGET2INF(flags, org_flags, O_NOCTTY);
 	ATHRILL_OPEN_R_FLAG_TARGET2INF(flags, org_flags, O_NONBLOCK);
 	ATHRILL_OPEN_R_FLAG_TARGET2INF(flags, org_flags, O_SYNC);
+#endif /* OS_LINUX */
 	ATHRILL_OPEN_R_FLAG_TARGET2INF(flags, org_flags, O_TRUNC);
 	ATHRILL_OPEN_R_FLAG_TARGET2INF(flags, org_flags, O_RDONLY);
 	ATHRILL_OPEN_R_FLAG_TARGET2INF(flags, org_flags, O_WRONLY);
@@ -326,9 +328,11 @@ static inline int athrill_syscall_open_r_flag(int inf_flags)
 	ATHRILL_OPEN_R_FLAG_INF2TARGET(flags, inf_flags, O_APPEND);
 	ATHRILL_OPEN_R_FLAG_INF2TARGET(flags, inf_flags, O_CREAT);
 	ATHRILL_OPEN_R_FLAG_INF2TARGET(flags, inf_flags, O_EXCL);
+#if OS_LINUX
 	ATHRILL_OPEN_R_FLAG_INF2TARGET(flags, inf_flags, O_NOCTTY);
 	ATHRILL_OPEN_R_FLAG_INF2TARGET(flags, inf_flags, O_NONBLOCK);
 	ATHRILL_OPEN_R_FLAG_INF2TARGET(flags, inf_flags, O_SYNC);
+#endif  /* OS_LINUX */
 	ATHRILL_OPEN_R_FLAG_INF2TARGET(flags, inf_flags, O_TRUNC);
 	ATHRILL_OPEN_R_FLAG_INF2TARGET(flags, inf_flags, O_RDONLY);
 	ATHRILL_OPEN_R_FLAG_INF2TARGET(flags, inf_flags, O_WRONLY);

--- a/src/device/mpu/loader/loader.c
+++ b/src/device/mpu/loader/loader.c
@@ -191,6 +191,7 @@ static Std_ReturnType Elf_LoadProgram(const Elf32_Ehdr *elf_image, MemoryAddress
 			set_malloc_region(memap, i);
 		}
 	}
+#ifdef	OS_LINUX	/* Windows not support */
 	for (i = 0; i < memap->dev_num; i++) {
 		ptr = mpu_address_set_dev(memap->dev[i].start, memap->dev[i].size, memap->dev[i].extdev_handle);
 		if (ptr == NULL) {
@@ -198,6 +199,7 @@ static Std_ReturnType Elf_LoadProgram(const Elf32_Ehdr *elf_image, MemoryAddress
 			return STD_E_INVALID;
 		}
 	}
+#endif /* OS_LINUX */
 	/*
 	 * set cache from elf file.
 	 */

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -43,6 +43,7 @@ static FILE *save_operation_fp = NULL;
 
 static void load_cui_operation(void)
 {
+#ifdef 	OS_LINUX	/* Windows not support */
 	DbgCmdExecutorType *res;
 	char *filename;
 	size_t buffer_size = 1024;
@@ -71,6 +72,7 @@ static void load_cui_operation(void)
 			res->run(res);
 		}
 	}
+#endif	/* OS_LINUX	 */
 	return;
 }
 static void save_cui_operation(const char* op)
@@ -116,6 +118,7 @@ retry:
 	}
 }
 
+#ifdef OS_LINUX
 static void athrill_sigterm_handler(int arg)
 {
 	athrill_device_cleanup();
@@ -127,6 +130,7 @@ static void athrill_sigterm_handler(int arg)
 	exit(0);
 	return;
 }
+#endif
 
 
 /*


### PR DESCRIPTION
MinGWではいくつかサポートしていないコードがあるため、OS_LINUXでビルドしないようにしました。