### PR TITLE
Windowビルドでエラーになる箇所の対応

### DIFF
--- a/src/device/peripheral/athrill_syscall_device.c
+++ b/src/device/peripheral/athrill_syscall_device.c
@@ -3,6 +3,7 @@
 #define ATHRILL_SYSCALL_DEVICE
 #include "athrill_syscall.h"
 #include <stdio.h>
+#include <stdint.h>
 #include <sys/fcntl.h>
 #include <sys/types.h>
 #ifdef  OS_LINUX

--- a/src/lib/target/target_os_api.h
+++ b/src/lib/target/target_os_api.h
@@ -49,8 +49,8 @@
  */
 #define TARGET_OS_SOCKET_TYPE	int
 #else
-#include <windows.h>
 #include <winsock2.h>
+#include <windows.h>
 /*
  * Winsock
  */

--- a/src/lib/tcp/tcp_client.c
+++ b/src/lib/tcp/tcp_client.c
@@ -1,7 +1,11 @@
 #include "tcp/tcp_client.h"
 #include <sys/types.h>
+#ifdef  OS_LINUX
 #include <sys/socket.h>
 #include <netinet/in.h>
+#else
+#include <winsock2.h>
+#endif
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>

--- a/src/lib/tcp/tcp_connection.c
+++ b/src/lib/tcp/tcp_connection.c
@@ -1,6 +1,10 @@
 #include "tcp_connection.h"
 #include <sys/types.h>
+#ifdef	OS_LINUX
 #include <sys/socket.h>
+#else
+#include <winsock2.h>
+#endif
 #include <errno.h>
 #include <stdio.h>
 
@@ -27,7 +31,11 @@ Std_ReturnType tcp_connection_send_nblk(TcpConnectionType *connection, const cha
 	ssize_t snd_size;
 
 	*res = 0;
+#ifdef	OS_LINUX
 	snd_size = send(connection->socket.fd, data, size, MSG_DONTWAIT);
+#else
+	snd_size = send(connection->socket.fd, data, size, 0);
+#endif
 	if (snd_size < 0) {
 		if (errno != EAGAIN) {
 			printf("ERROR: tcp_connection_send() errno=%d\n", errno);
@@ -47,7 +55,11 @@ Std_ReturnType tcp_connection_receive_nblk(TcpConnectionType *connection, char *
 {
 	ssize_t rcv_size;
 	*res = 0;
+#ifdef	OS_LINUX
 	rcv_size = recv(connection->socket.fd, data, size, MSG_DONTWAIT);
+#else
+	rcv_size = recv(connection->socket.fd, data, size, 0);
+#endif
 	if (rcv_size < 0) {
 		if (errno != EAGAIN) {
 			printf("ERROR: tcp_connection_receive() errno=%d\n", errno);

--- a/src/lib/tcp/tcp_server.c
+++ b/src/lib/tcp/tcp_server.c
@@ -1,7 +1,11 @@
 #include "tcp/tcp_server.h"
 #include <sys/types.h>
+#ifdef  OS_LINUX
 #include <sys/socket.h>
 #include <netinet/in.h>
+#else
+#include <winsock2.h>
+#endif
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>
@@ -39,8 +43,11 @@ Std_ReturnType tcp_server_create(const TcpServerConfigType *config, TcpServerTyp
 Std_ReturnType tcp_server_accept(const TcpServerType *server, TcpConnectionType *connection)
 {
 	struct sockaddr_in addr;
+#ifdef  OS_LINUX
     socklen_t len = sizeof(struct sockaddr_in);
-
+#else
+    int len = sizeof(struct sockaddr_in);
+#endif
 	//printf("tcp_server_accept: fd=%d\n", server->socket.fd);
     connection->socket.fd = accept(server->socket.fd, (struct sockaddr *)&addr, &len);
     if (connection->socket.fd < 0) {

--- a/src/lib/tcp/tcp_socket.c
+++ b/src/lib/tcp/tcp_socket.c
@@ -1,9 +1,13 @@
 #include "tcp_socket.h"
 #include <unistd.h>
 #include <sys/types.h>
+#ifdef	OS_LINUX
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <netdb.h>
+#else
+#include <winsock2.h>
+#endif
 #include <stdio.h>
 #include <errno.h>
 #include <string.h>


### PR DESCRIPTION
Windowsビルド(MinGW)する際にsocket関連がエラーになってしまうので、winsock2.hに置き換えるように追加しました。
ですが、can, mrosのビルドにはまだ対応していません。