### PR TITLE
fix clang 15.0.7 compile error

### DIFF
--- a/src/main/cpuemu.c
+++ b/src/main/cpuemu.c
@@ -438,7 +438,7 @@ void *cpuemu_thread_run(void* arg)
 {
 	std_bool is_halt;
 	int core_id_num = cpu_config_get_core_id_num();
-	static bool (*do_cpu_run) (int);
+	static std_bool (*do_cpu_run) (int);
 	int core_id;
 
 	enable_dbg.enable_bt = TRUE;


### PR DESCRIPTION
Fix bool to std_bool, because function pointer types is mismatch.

clang 15.0.7の環境でビルドエラーが発生することがわかりましたので、
ビルドエラーを回避するパッチを作成しました。